### PR TITLE
Changes to allow Teamcity to see Tests failed or Tests passed strings to mark a build red or green

### DIFF
--- a/src/main/java/uk/co/automatictester/lightning/ci/TeamCityReporter.java
+++ b/src/main/java/uk/co/automatictester/lightning/ci/TeamCityReporter.java
@@ -16,4 +16,12 @@ public class TeamCityReporter extends CIReporter {
         System.out.println(String.format(teamCityOutput, getReportSummary(jmeterTransactions)));
     }
 
+	public static String getVerifySummary(TestSet testSet) {
+		int executed = testSet.getTestCount();
+		int failed = testSet.getFailCount();
+		int ignored = testSet.getIgnoreCount();
+		String testMsgHead = failed > 0 ? "Tests failed:" : "Tests passed:";
+		return String.format(testMsgHead + " executed: %s, failed: %s, ignored: %s", executed, failed, ignored);
+	}
+
 }

--- a/src/test/java/uk/co/automatictester/lightning/ci/TeamCityReporterTest.java
+++ b/src/test/java/uk/co/automatictester/lightning/ci/TeamCityReporterTest.java
@@ -13,9 +13,9 @@ import static org.mockito.Mockito.when;
 public class TeamCityReporterTest extends ConsoleOutputTest {
 
     @Test
-    public void testSetTeamCityBuildStatusText_verify() {
+    public void testSetTeamCityBuildStatusTextFailedTests_verify() {
         String expectedOutput = String.format("%nSet TeamCity build status text:%n" +
-                "##teamcity[buildStatus text='Tests executed: 6, failed: 2, ignored: 1']%n");
+                "##teamcity[buildStatus text='Tests failed: executed: 6, failed: 2, ignored: 1']%n");
 
         TestSet testSet = mock(TestSet.class);
         when(testSet.getTestCount()).thenReturn(6);
@@ -27,6 +27,22 @@ public class TeamCityReporterTest extends ConsoleOutputTest {
         assertThat(out.toString(), containsString(expectedOutput));
         revertStream();
     }
+
+	@Test
+	public void testSetTeamCityBuildStatusTextZeroFailedTests_verify() {
+		String expectedOutput = String.format("%nSet TeamCity build status text:%n" +
+				"##teamcity[buildStatus text='Tests passed: executed: 6, failed: 0, ignored: 1']%n");
+
+		TestSet testSet = mock(TestSet.class);
+		when(testSet.getTestCount()).thenReturn(6);
+		when(testSet.getFailCount()).thenReturn(0);
+		when(testSet.getIgnoreCount()).thenReturn(1);
+
+		configureStream();
+		new TeamCityReporter().setTeamCityBuildStatusText(testSet);
+		assertThat(out.toString(), containsString(expectedOutput));
+		revertStream();
+	}
 
     @Test
     public void testSetTeamCityBuildStatusText_report() {


### PR DESCRIPTION
Changes to allow Teamcity to see Tests failed or Tests passed strings to mark a build red or green.
I am new to do a pull request and contribute, please let me know if anything is missing.