### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/uk/co/automatictester/lightning/cli/commands/CommandVerify.java
+++ b/src/main/java/uk/co/automatictester/lightning/cli/commands/CommandVerify.java
@@ -39,6 +39,6 @@ public class CommandVerify {
     }
 
     public boolean isPerfmonCsvFileProvided() {
-        return (perfmonCsvFile != null);
+        return perfmonCsvFile != null;
     }
 }

--- a/src/main/java/uk/co/automatictester/lightning/cli/delegates/CI.java
+++ b/src/main/java/uk/co/automatictester/lightning/cli/delegates/CI.java
@@ -14,7 +14,7 @@ public class CI {
         if (this.ci == null) {
             return false;
         } else {
-            return (this.ci.toLowerCase().equals(ci));
+            return this.ci.toLowerCase().equals(ci);
         }
     }
 

--- a/src/main/java/uk/co/automatictester/lightning/cli/validators/CIServerValidator.java
+++ b/src/main/java/uk/co/automatictester/lightning/cli/validators/CIServerValidator.java
@@ -13,7 +13,7 @@ public class CIServerValidator implements IParameterValidator {
         ciServers.add("jenkins");
         ciServers.add("teamcity");
 
-        if (!(ciServers.contains(value.toLowerCase()))) {
+        if (!ciServers.contains(value.toLowerCase())) {
             throw new ParameterException(String.format("CI server '%s' not in list: %s", value, ciServers.toString()));
         }
     }

--- a/src/main/java/uk/co/automatictester/lightning/data/JMeterTransactions.java
+++ b/src/main/java/uk/co/automatictester/lightning/data/JMeterTransactions.java
@@ -51,7 +51,7 @@ public class JMeterTransactions extends ArrayList<ArrayList<String>> {
     }
 
     public double getThroughput() {
-        double transactionTimespanInMilliseconds = (getLastTransactionTimestamp() - getFirstTransactionTimestamp());
+        double transactionTimespanInMilliseconds = getLastTransactionTimestamp() - getFirstTransactionTimestamp();
         return getTransactionCount() / (transactionTimespanInMilliseconds / 1000);
     }
 

--- a/src/main/java/uk/co/automatictester/lightning/readers/LightningXMLFileReader.java
+++ b/src/main/java/uk/co/automatictester/lightning/readers/LightningXMLFileReader.java
@@ -59,8 +59,8 @@ public class LightningXMLFileReader extends LightningXMLProcessingHelpers {
 
     private int getTestCount() {
         return
-                ((clientSideTests != null) ? clientSideTests.size() : 0) +
-                ((serverSideTests != null) ? serverSideTests.size() : 0);
+                (clientSideTests != null ? clientSideTests.size() : 0) +
+                (serverSideTests != null ? serverSideTests.size() : 0);
     }
 
     private void addPassedTransactionsTestNodes(Document xmlDoc) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.