### PR TITLE
Continue test on fail when multiple testsets are configured

### DIFF
--- a/jmeter-lightning-maven-plugin/src/it/e2e/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/e2e/pom.xml
@@ -53,8 +53,12 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>src/test/resources/xml/lightning.xml</testSetXml>
-                            <jmeterCsv>target/jmeter/results/example.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>src/test/resources/xml/lightning.xml</testSetXml>
+                                    <jmeterCsv>target/jmeter/results/example.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/jenkins-report/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/jenkins-report/pom.xml
@@ -25,7 +25,11 @@
                         </goals>
                         <configuration>
                             <mode>report</mode>
-                            <jmeterCsv>data/2_1_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <jmeterCsv>data/2_1_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/jenkins-verify/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/jenkins-verify/pom.xml
@@ -25,8 +25,12 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>data/1_1_1.xml</testSetXml>
-                            <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>data/1_1_1.xml</testSetXml>
+                                    <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/junit-test-a-expected.xml
+++ b/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/junit-test-a-expected.xml
@@ -1,5 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?><testsuite errors="0" failures="0" name="Lightning" tests="3" time="0">
-    <testcase name="Average response time" time="0"/>
+<?xml version="1.0" encoding="UTF-8"?><testsuite errors="0" failures="1" name="Lightning" tests="3" time="0">
+    <testcase name="Average response time" time="0">
+        <failure message="Average response time = 11221" type="avgRespTimeTest">Test name:            Average response time
+Test type:            avgRespTimeTest
+Transaction name:     Login
+Expected result:      Average response time &lt;= 1000
+Actual result:        Average response time = 11221
+Transaction count:    1
+Longest transactions: [11221]
+Test result:          FAIL
+</failure>
+    </testcase>
     <testcase name="No failed transactions" time="0"/>
     <testcase name="CPU utilisation" time="0"/>
 </testsuite>

--- a/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/junit-test-b-expected.xml
+++ b/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/junit-test-b-expected.xml
@@ -1,15 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><testsuite errors="0" failures="1" name="Lightning" tests="3" time="0">
-    <testcase name="Average response time" time="0">
-        <failure message="Average response time = 11221" type="avgRespTimeTest">Test name:            Average response time
-Test type:            avgRespTimeTest
-Transaction name:     Search
-Expected result:      Average response time &lt;= 1000
-Actual result:        Average response time = 11221
-Transaction count:    1
-Longest transactions: [11221]
-Test result:          FAIL
-</failure>
-    </testcase>
+<?xml version="1.0" encoding="UTF-8"?><testsuite errors="0" failures="0" name="Lightning" tests="3" time="0">
+    <testcase name="Average response time" time="0"/>
     <testcase name="No failed transactions" time="0"/>
     <testcase name="CPU utilisation" time="0"/>
 </testsuite>

--- a/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/results-a.csv
+++ b/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/results-a.csv
@@ -1,2 +1,2 @@
 timeStamp,elapsed,label,responseCode,threadName,dataType,success,bytes,Latency
-1434291247743,500,Login,200,Thread Group 1-2,,true,444013,0
+1434291247743,11221,Login,200,Thread Group 1-2,,true,444013,0

--- a/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/results-b.csv
+++ b/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/data/results-b.csv
@@ -1,2 +1,2 @@
 timeStamp,elapsed,label,responseCode,threadName,dataType,success,bytes,Latency
-1434291252072,11221,Search,200,Thread Group 1-5,,true,1912175,0
+1434291252072,500,Search,200,Thread Group 1-5,,true,1912175,0

--- a/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/junit-report-suffix/pom.xml
@@ -20,29 +20,26 @@
                 <version>@project.version@</version>
                 <executions>
                     <execution>
-                        <id>test-a</id>
+                        <phase>integration-test</phase>
                         <goals>
                             <goal>lightning</goal>
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <junitReportSuffix>test-a</junitReportSuffix>
-                            <testSetXml>data/test-a.xml</testSetXml>
-                            <jmeterCsv>data/results-a.csv</jmeterCsv>
-                            <perfmonCsv>data/perf-a.csv</perfmonCsv>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-b</id>
-                        <goals>
-                            <goal>lightning</goal>
-                        </goals>
-                        <configuration>
-                            <mode>verify</mode>
-                            <junitReportSuffix>test-b</junitReportSuffix>
-                            <testSetXml>data/test-b.xml</testSetXml>
-                            <jmeterCsv>data/results-b.csv</jmeterCsv>
-                            <perfmonCsv>data/perf-b.csv</perfmonCsv>
+                            <testSets>
+                                <testSet>
+                                    <junitReportSuffix>test-a</junitReportSuffix>
+                                    <testSetXml>data/test-a.xml</testSetXml>
+                                    <jmeterCsv>data/results-a.csv</jmeterCsv>
+                                    <perfmonCsv>data/perf-a.csv</perfmonCsv>
+                                </testSet>
+                                <testSet>
+                                    <junitReportSuffix>test-b</junitReportSuffix>
+                                    <testSetXml>data/test-b.xml</testSetXml>
+                                    <jmeterCsv>data/results-b.csv</jmeterCsv>
+                                    <perfmonCsv>data/perf-b.csv</perfmonCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/junit-report/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/junit-report/pom.xml
@@ -25,9 +25,13 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>data/junit_report.xml</testSetXml>
-                            <jmeterCsv>data/2_transactions.csv</jmeterCsv>
-                            <perfmonCsv>data/junit_report.csv</perfmonCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>data/junit_report.xml</testSetXml>
+                                    <jmeterCsv>data/2_transactions.csv</jmeterCsv>
+                                    <perfmonCsv>data/junit_report.csv</perfmonCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/report-fail/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/report-fail/pom.xml
@@ -25,7 +25,11 @@
                         </goals>
                         <configuration>
                             <mode>report</mode>
-                            <jmeterCsv>data/2_1_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <jmeterCsv>data/2_1_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/report-pass/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/report-pass/pom.xml
@@ -25,7 +25,11 @@
                         </goals>
                         <configuration>
                             <mode>report</mode>
-                            <jmeterCsv>data/2_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <jmeterCsv>data/2_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/verify-fail/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/verify-fail/pom.xml
@@ -25,8 +25,12 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>data/1_1_1.xml</testSetXml>
-                            <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>data/1_1_1.xml</testSetXml>
+                                    <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/verify-pass-server-side/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/verify-pass-server-side/pom.xml
@@ -25,9 +25,13 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>data/1_client_2_server.xml</testSetXml>
-                            <jmeterCsv>data/10_transactions.csv</jmeterCsv>
-                            <perfmonCsv>data/2_entries.csv</perfmonCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>data/1_client_2_server.xml</testSetXml>
+                                    <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                                    <perfmonCsv>data/2_entries.csv</perfmonCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/verify-pass/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/verify-pass/pom.xml
@@ -25,8 +25,12 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>data/3_0_0.xml</testSetXml>
-                            <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>data/3_0_0.xml</testSetXml>
+                                    <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/it/verify-regexp/pom.xml
+++ b/jmeter-lightning-maven-plugin/src/it/verify-regexp/pom.xml
@@ -25,8 +25,12 @@
                         </goals>
                         <configuration>
                             <mode>verify</mode>
-                            <testSetXml>data/regexp.xml</testSetXml>
-                            <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                            <testSets>
+                                <testSet>
+                                    <testSetXml>data/regexp.xml</testSetXml>
+                                    <jmeterCsv>data/10_transactions.csv</jmeterCsv>
+                                </testSet>
+                            </testSets>
                         </configuration>
                     </execution>
                 </executions>

--- a/jmeter-lightning-maven-plugin/src/main/java/uk/co/automatictester/jmeter/lightning/maven/plugin/ConfigurationMojo.java
+++ b/jmeter-lightning-maven-plugin/src/main/java/uk/co/automatictester/jmeter/lightning/maven/plugin/ConfigurationMojo.java
@@ -4,7 +4,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import uk.co.automatictester.lightning.core.enums.Mode;
 
-import java.io.File;
+import java.util.List;
 
 abstract class ConfigurationMojo extends AbstractMojo {
 
@@ -16,26 +16,12 @@ abstract class ConfigurationMojo extends AbstractMojo {
     Mode mode;
 
     /**
-     * Lightning XML config file with test definitions
-     */
-    @Parameter
-    File testSetXml;
-
-    /**
-     * JMeter CSV file
+     * A list of TestSets to be executed, containing properties:
+     * testSetXml,
+     * jmeterCsv (required),
+     * perfmonCsv,
+     * junitReportSuffix
      */
     @Parameter(required = true)
-    File jmeterCsv;
-
-    /**
-     * PerfMon CSV file
-     */
-    @Parameter
-    File perfmonCsv;
-
-    /**
-     * JUnit report suffix
-     */
-    @Parameter
-    String junitReportSuffix;
+    List<TestSet> testSets;
 }

--- a/jmeter-lightning-maven-plugin/src/main/java/uk/co/automatictester/jmeter/lightning/maven/plugin/LightningMojo.java
+++ b/jmeter-lightning-maven-plugin/src/main/java/uk/co/automatictester/jmeter/lightning/maven/plugin/LightningMojo.java
@@ -5,6 +5,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import uk.co.automatictester.lightning.core.facades.LightningCoreLocalFacade;
 
+import java.io.File;
+
 @Mojo(name = "lightning", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
 public class LightningMojo extends ConfigurationMojo {
 
@@ -13,27 +15,29 @@ public class LightningMojo extends ConfigurationMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        core.setJmeterCsv(jmeterCsv);
-        core.setPerfMonCsv(perfmonCsv);
-        core.setJunitReportSuffix(junitReportSuffix);
-        core.loadTestData();
 
-        switch (mode) {
-            case verify:
-                runTests();
-                core.saveJunitReport();
-                notifyCiServerForVerify();
-                break;
-            case report:
-                runReport();
-                notifyCiServerForReport();
-                break;
+        for (TestSet testSet : testSets) {
+            core.setJmeterCsv(testSet.getJmeterCsv());
+            core.setPerfMonCsv(testSet.getPerfmonCsv());
+            core.setJunitReportSuffix(testSet.getJunitReportSuffix());
+            core.loadTestData();
+
+            switch (mode) {
+                case verify:
+                    runTests(testSet.getTestSetXml());
+                    core.saveJunitReport();
+                    notifyCiServerForVerify();
+                    break;
+                case report:
+                    runReport();
+                    notifyCiServerForReport();
+                    break;
+            }
         }
-
         setExitCode();
     }
 
-    private void runTests() {
+    private void runTests(File testSetXml) {
         long testSetExecStart = System.currentTimeMillis();
 
         core.setLightningXml(testSetXml);

--- a/jmeter-lightning-maven-plugin/src/main/java/uk/co/automatictester/jmeter/lightning/maven/plugin/TestSet.java
+++ b/jmeter-lightning-maven-plugin/src/main/java/uk/co/automatictester/jmeter/lightning/maven/plugin/TestSet.java
@@ -1,0 +1,31 @@
+package uk.co.automatictester.jmeter.lightning.maven.plugin;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.File;
+
+public class TestSet {
+
+  private File testSetXml;
+  private File jmeterCsv;
+  private File perfmonCsv;
+  private String junitReportSuffix;
+
+  File getTestSetXml() {
+    return testSetXml;
+  }
+
+  File getJmeterCsv() throws MojoExecutionException {
+    if (jmeterCsv == null)
+      throw new MojoExecutionException("jmeterCsv is a required parameter");
+    return jmeterCsv;
+  }
+
+  File getPerfmonCsv() {
+    return perfmonCsv;
+  }
+
+  String getJunitReportSuffix() {
+    return junitReportSuffix;
+  }
+}


### PR DESCRIPTION
This PR is in relation to #110 and `jmeter-lightning-maven-plugin`.

When multiple executions are defined, and a lightning test fails, any subsequent executions do not occur, and behaves in a fail-fast manner. For my use case, i'd like the plugin to continue executing so that any performance regression is identified across all test cases, not just at the first case that fails.

The solution i propose introduces a new mojo parameter, a List of TestSet objects which contain the original parameters. So the configuration block would look like:

``` xml
<configuration>
  <mode>verify</mode>
  <testSets>
    <testSet>
      <junitReportSuffix>test-a</junitReportSuffix>
      <testSetXml>data/test-a.xml</testSetXml>
      <jmeterCsv>data/results-a.csv</jmeterCsv>
      <perfmonCsv>data/perf-a.csv</perfmonCsv>
    </testSet>
    <testSet>
      <junitReportSuffix>test-b</junitReportSuffix>
      <testSetXml>data/test-b.xml</testSetXml>
      <jmeterCsv>data/results-b.csv</jmeterCsv>
      <perfmonCsv>data/perf-b.csv</perfmonCsv>
    </testSet>
  </testSets>
</configuration>
```

Then `LightningMojo` iterates over this list, executing each test set, then decides whether or not to throw `MojoExecutionException` at the end of the loop.

I understand this is quite a drastic/breaking change, so i completely understand if you feel hesitant to approve. If so, i'd be more than happy to work towards a compromise or alternative. Appreciate it!